### PR TITLE
Update Dependencies

### DIFF
--- a/orika-spring-boot-starter-sample/.mvn/wrapper/maven-wrapper.properties
+++ b/orika-spring-boot-starter-sample/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip

--- a/orika-spring-boot-starter-sample/pom.xml
+++ b/orika-spring-boot-starter-sample/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.3.RELEASE</version>
     </parent>
 
     <dependencies>

--- a/orika-spring-boot-starter/.mvn/wrapper/maven-wrapper.properties
+++ b/orika-spring-boot-starter/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip

--- a/orika-spring-boot-starter/pom.xml
+++ b/orika-spring-boot-starter/pom.xml
@@ -126,7 +126,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.3</version>
                 <configuration>
                     <append>false</append>
                 </configuration>
@@ -162,6 +162,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <trimStackTrace>false</trimStackTrace>
@@ -265,7 +266,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -276,7 +277,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.0.0-M3</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -288,7 +289,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.3</version>
                 <configuration>
                     <excludes>
                         <exclude>net/rakugakibox/spring/boot/orika/OrikaProperties.class</exclude>

--- a/orika-spring-boot-starter/pom.xml
+++ b/orika-spring-boot-starter/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.3.RELEASE</version>
     </parent>
 
     <organization>
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>ma.glasnost.orika</groupId>
             <artifactId>orika-core</artifactId>
-            <version>1.5.2</version>
+            <version>1.5.4</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This Commit Updates orika-core to version 1.5.4
and spring-boot-starter-parent to 2.1.3

includes changes from https://github.com/akihyro/orika-spring-boot-starter/pull/10