### PR TITLE
Update Maven and Maven Plugins & fix breaking builds

### DIFF
--- a/orika-spring-boot-starter-sample/.mvn/wrapper/maven-wrapper.properties
+++ b/orika-spring-boot-starter-sample/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip

--- a/orika-spring-boot-starter/.mvn/wrapper/maven-wrapper.properties
+++ b/orika-spring-boot-starter/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip

--- a/orika-spring-boot-starter/pom.xml
+++ b/orika-spring-boot-starter/pom.xml
@@ -126,7 +126,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.3</version>
                 <configuration>
                     <append>false</append>
                 </configuration>
@@ -162,6 +162,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <trimStackTrace>false</trimStackTrace>
@@ -265,7 +266,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -276,7 +277,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.0.0-M3</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -288,7 +289,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.3</version>
                 <configuration>
                     <excludes>
                         <exclude>net/rakugakibox/spring/boot/orika/OrikaProperties.class</exclude>


### PR DESCRIPTION
This commit updates maven to 3.6.0
and updates several plugins to their latest versions

I had to update the surefire plugin to 3.0.0-M3 because of 
https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class/53016532#53016532